### PR TITLE
Fix header filename typo

### DIFF
--- a/utils/app_config.py
+++ b/utils/app_config.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # -----------------------------------------------------------------------------
-# File: app_confg.py
+# File: app_config.py
 # Description: Class to handle application configuration, including system detection
 # and data directory management.
 # Author: Jereme Shaver


### PR DESCRIPTION
## Summary
- correct the filename in `utils/app_config.py` header comment

## Testing
- `python -m py_compile utils/app_config.py` *(fails: SyntaxError unrelated to change)*

------
https://chatgpt.com/codex/tasks/task_e_683fbc5874b8832ea382dc78be8c1d6f