### PR TITLE
Implement NodeItem serialization with tests

### DIFF
--- a/tests/test_node_serialization.py
+++ b/tests/test_node_serialization.py
@@ -1,0 +1,150 @@
+import os
+import sys
+import types
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub modules that bring in heavy PyQt dependencies
+dummy_collapsible = types.ModuleType("ui.custom_widgets.collapsable_section")
+dummy_collapsible.CollapsibleSection = type("CollapsibleSection", (), {})
+sys.modules.setdefault("ui.custom_widgets.collapsable_section", dummy_collapsible)
+
+dummy_styles = types.ModuleType("resources.styles")
+dummy_styles.AppColors = type("AppColors", (), {})
+dummy_styles.AppStyles = type("AppStyles", (), {})
+dummy_styles.AnimatedButton = type("AnimatedButton", (), {})
+sys.modules.setdefault("resources.styles", dummy_styles)
+sys.modules.setdefault("resources.styles.styles", dummy_styles)
+
+# ---- PyQt5 stubs ----
+qt_pkg = types.ModuleType("PyQt5")
+sys.modules.setdefault("PyQt5", qt_pkg)
+
+qtcore = types.ModuleType("PyQt5.QtCore")
+class DummyPointF:
+    def __init__(self, x=0, y=0):
+        self._x = x
+        self._y = y
+    def x(self):
+        return self._x
+    def y(self):
+        return self._y
+qtcore.QPointF = DummyPointF
+qtcore.Qt = types.SimpleNamespace(NoButton=0)
+qtcore.QObject = object
+qtcore.QPropertyAnimation = type('QPropertyAnimation', (), {})
+qtcore.QEasingCurve = type('QEasingCurve', (), {})
+qtcore.QSize = type('QSize', (), {})
+qtcore.QEvent = type('QEvent', (), {})
+qtcore.QDateTime = type('QDateTime', (), {})
+qtcore.QUrl = type('QUrl', (), {})
+qtcore.QTimer = type('QTimer', (), {})
+qtcore.pyqtSignal = lambda *a, **k: None
+qtcore.pyqtSlot = lambda *a, **k: None
+sys.modules["PyQt5.QtCore"] = qtcore
+
+qtwidgets = types.ModuleType("PyQt5.QtWidgets")
+class DummyEllipseItem:
+    ItemIsSelectable = 1
+    ItemIsMovable = 2
+    ItemSendsGeometryChanges = 4
+    def __init__(self, *a, **kw):
+        self._pos = DummyPointF(0, 0)
+    def setPen(self, *a, **kw):
+        pass
+    def setBrush(self, *a, **kw):
+        pass
+    def setFlags(self, *a, **kw):
+        pass
+    def setAcceptHoverEvents(self, *a, **kw):
+        pass
+    def setRect(self, *a, **kw):
+        self.rect = a
+    def setPos(self, x, y=None):
+        if y is None and hasattr(x, "x"):
+            self._pos = x
+        else:
+            self._pos = DummyPointF(x, y)
+    def pos(self):
+        return self._pos
+qtwidgets.QGraphicsEllipseItem = DummyEllipseItem
+
+class DummyTextItem:
+    def __init__(self, text="", parent=None):
+        self._text = text
+    def toPlainText(self):
+        return self._text
+    def setPlainText(self, text):
+        self._text = text
+    def setDefaultTextColor(self, color):
+        pass
+    def setTextWidth(self, width):
+        pass
+    def document(self):
+        return self
+    def adjustSize(self):
+        pass
+    def boundingRect(self):
+        class R:
+            def width(self):
+                return 0
+            def height(self):
+                return 0
+        return R()
+qtwidgets.QGraphicsTextItem = DummyTextItem
+
+for name in [
+    'QApplication','QDesktopWidget','QGraphicsLineItem','QGraphicsItem','QWidget','QVBoxLayout','QHBoxLayout',
+    'QLabel','QFrame','QSpacerItem','QSizePolicy','QGridLayout','QPushButton',
+    'QGraphicsDropShadowEffect','QStyle','QComboBox','QTextEdit','QDateTimeEdit',
+    'QLineEdit','QCalendarWidget','QToolButton','QSpinBox','QListWidget',
+    'QTabWidget','QGraphicsRectItem','QMessageBox','QInputDialog','QListWidgetItem',
+    'QScrollArea','QTreeWidget','QTreeWidgetItem','QFileDialog','QStyleFactory',
+    'QListView','QLayout','QSplitter']:
+    setattr(qtwidgets, name, type(name, (), {}))
+
+sys.modules["PyQt5.QtWidgets"] = qtwidgets
+
+qtgui = types.ModuleType("PyQt5.QtGui")
+for name in [
+    'QColor','QPainter','QBrush','QPen','QMovie','QTextCharFormat','QIcon',
+    'QPixmap','QDesktopServices']:
+    setattr(qtgui, name, type(name, (), {}))
+sys.modules['PyQt5.QtGui'] = qtgui
+
+qtsvg = types.ModuleType('PyQt5.QtSvg')
+qtsvg.QSvgWidget = type('QSvgWidget', (), {})
+sys.modules['PyQt5.QtSvg'] = qtsvg
+
+# ---- import NodeItem ----
+from ui.custom_widgets.mindmap_nodes import NodeItem
+
+
+def test_nodeitem_serialization_round_trip():
+    node = NodeItem.__new__(NodeItem)
+    DummyEllipseItem.__init__(node)
+    node.id = 'node1'
+    node.width = 120
+    node.height = 80
+    node.text_item = DummyTextItem('hello')
+    node.update_node_layout = lambda: None
+    node.setRect = lambda *a, **k: None
+    node.setPos(10, 15)
+
+    data = node.serialize()
+
+    other = NodeItem.__new__(NodeItem)
+    DummyEllipseItem.__init__(other)
+    other.text_item = DummyTextItem()
+    other.update_node_layout = lambda: None
+    other.setRect = lambda *a, **k: None
+    other.id = None
+    other.width = 0
+    other.height = 0
+    other.deserialize(data)
+
+    assert other.id == node.id
+    assert other.text_item.toPlainText() == 'hello'
+    assert other.width == 120 and other.height == 80
+    assert other.pos().x() == 10
+    assert other.pos().y() == 15

--- a/ui/custom_widgets/mindmap_nodes.py
+++ b/ui/custom_widgets/mindmap_nodes.py
@@ -405,3 +405,33 @@ class NodeItem(QGraphicsEllipseItem):
         new_x = (self.width - txt_bounds.width()) / 2
         new_y = (self.height - txt_bounds.height()) / 2
         self.text_item.setPos(new_x, new_y)
+
+    def serialize(self):
+        """Return a JSON serializable representation of this node."""
+        pos = self.pos()
+        return {
+            "id": self.id,
+            "text": self.text_item.toPlainText(),
+            "width": self.width,
+            "height": self.height,
+            "position": {"x": pos.x(), "y": pos.y()},
+        }
+
+    def deserialize(self, data: dict):
+        """Restore the node state from ``data`` produced by :meth:`serialize`."""
+        self.id = data.get("id", self.id)
+        self.width = data.get("width", self.width)
+        self.height = data.get("height", self.height)
+        self.text_item.setPlainText(data.get("text", ""))
+
+        # Update geometry and layout
+        if hasattr(self, "setRect"):
+            self.setRect(0, 0, self.width, self.height)
+        if hasattr(self, "update_node_layout"):
+            self.update_node_layout()
+
+        pos = data.get("position", {})
+        x = pos.get("x", 0)
+        y = pos.get("y", 0)
+        if hasattr(self, "setPos"):
+            self.setPos(x, y)

--- a/ui/mindmap_screen.py
+++ b/ui/mindmap_screen.py
@@ -161,22 +161,40 @@ class MindMapScreen(QWidget):
     def save_mind_map(self):
         # Serialize and save all NodeItems in the scene.
         nodes = [item.serialize() for item in self.scene.items() if isinstance(item, NodeItem)]
+        connections = getattr(self.scene, "connections", [])
+
+        data = {"nodes": nodes}
+        if connections:
+            data["connections"] = connections
+
         fileName, _ = QFileDialog.getSaveFileName(self, "Save Mind Map", "", "JSON Files (*.json)")
         if fileName:
             with open(fileName, 'w') as f:
-                json.dump(nodes, f, indent=4)
+                json.dump(data, f, indent=4)
 
     def load_mind_map(self):
         # Load and deserialize nodes from a JSON file.
         fileName, _ = QFileDialog.getOpenFileName(self, "Load Mind Map", "", "JSON Files (*.json)")
         if fileName:
             with open(fileName, 'r') as f:
-                nodes_data = json.load(f)
+                data = json.load(f)
+
+            if isinstance(data, list):
+                nodes_data = data
+                connections_data = []
+            else:
+                nodes_data = data.get("nodes", [])
+                connections_data = data.get("connections", [])
+
             self.clear_map()  # Clear existing items in the scene.
             for node_data in nodes_data:
                 node = NodeItem(0, 0)
                 node.deserialize(node_data)
                 self.scene.addItem(node)
+
+            # Placeholder for future connection handling
+            if connections_data and hasattr(self.scene, "connections"):
+                self.scene.connections = connections_data
 
     def clear_map(self):
         # Remove all items from the scene.


### PR DESCRIPTION
## Summary
- add serialization/deserialization logic for `NodeItem`
- extend mind map save/load to use new format
- provide unit test for NodeItem round‑trip serialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc157b444832e913a20ed54603a00