### PR TITLE
Implement hover overlays for task cards

### DIFF
--- a/ui/dashboard_child_view/grid_layout.py
+++ b/ui/dashboard_child_view/grid_layout.py
@@ -275,19 +275,10 @@ class GridLayout(QWidget):
         sender_card = self.sender()
 
         if sender_card and self.grid_title == sender_card.task.category.value:
-            sender_card.setExpanded(is_hovering)
-
-            parent_grid_section = self.parentWidget()  # Get the QWidget that holds this grid
-
-            if parent_grid_section:
-                parent_grid_section.setUpdatesEnabled(False)  # Prevent layout updates
-            
             if is_hovering:
-                sender_card.updateGeometry()  # Update only this card
-                self.setMinimumHeight(self.sizeHint().height())  # Only adjust this grid's height
-            
-            if parent_grid_section:
-                parent_grid_section.setUpdatesEnabled(True)  # Re-enable updates
+                sender_card.showHoverOverlay()
+            else:
+                sender_card.hideHoverOverlay()
 
 
     def handleCardClicked(self, task):


### PR DESCRIPTION
## Summary
- add hover overlay widget to `TaskCardLite`
- manage overlay visibility from `GridLayout`
- clean up layout resizing logic

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'QGraphicsPathItem' from 'PyQt5.QtWidgets')*

------
https://chatgpt.com/codex/tasks/task_e_683fc7e0f714832e8c0fbfd91cb198f8