### PR TITLE
Fix overlay size for TaskCardLite

### DIFF
--- a/ui/task_files/task_card_lite.py
+++ b/ui/task_files/task_card_lite.py
@@ -135,6 +135,9 @@ class TaskCardLite(QWidget):
         self.hoverOverlay = QWidget(self.parentWidget())
         self.hoverOverlay.setObjectName("card_container")
         self.hoverOverlay.setStyleSheet(self.styleSheet())
+        # Ensure the overlay matches the card's dimensions
+        self.hoverOverlay.setFixedWidth(self.width())
+        self.hoverOverlay.setFixedHeight(self.expanded_height)
         layout = QVBoxLayout(self.hoverOverlay)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)


### PR DESCRIPTION
## Summary
- ensure hover overlay expands to card width and uses `expanded_height`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'QGraphicsPathItem' from 'PyQt5.QtWidgets')*

------
https://chatgpt.com/codex/tasks/task_e_683fcfd53b34832ea05e436b05b9094f