### PR TITLE
Fix hover overlay transparency

### DIFF
--- a/ui/task_files/task_card_lite.py
+++ b/ui/task_files/task_card_lite.py
@@ -135,6 +135,9 @@ class TaskCardLite(QWidget):
         self.hoverOverlay = QWidget(self.parentWidget())
         self.hoverOverlay.setObjectName("card_container")
         self.hoverOverlay.setStyleSheet(self.styleSheet())
+        # Allow hover events to pass through the overlay so the card still
+        # receives them even when covered
+        self.hoverOverlay.setAttribute(Qt.WA_TransparentForMouseEvents, True)
         layout = QVBoxLayout(self.hoverOverlay)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)


### PR DESCRIPTION
## Summary
- allow TaskCardLite overlay to forward mouse events to the card

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'QGraphicsPathItem')*

------
https://chatgpt.com/codex/tasks/task_e_683fcfdb5bb4832e9dd662b85c100ae5