### PR TITLE
Handle hover overlay mouse events

### DIFF
--- a/tests/test_node_serialization.py
+++ b/tests/test_node_serialization.py
@@ -100,7 +100,7 @@ for name in [
     'QLineEdit','QCalendarWidget','QToolButton','QSpinBox','QListWidget',
     'QTabWidget','QGraphicsRectItem','QMessageBox','QInputDialog','QListWidgetItem',
     'QScrollArea','QTreeWidget','QTreeWidgetItem','QFileDialog','QStyleFactory',
-    'QListView','QLayout','QSplitter']:
+    'QListView','QLayout','QSplitter','QGraphicsPathItem']:
     setattr(qtwidgets, name, type(name, (), {}))
 
 sys.modules["PyQt5.QtWidgets"] = qtwidgets


### PR DESCRIPTION
## Summary
- enable mouse events on hover overlay
- add event filter to hide overlay when pointer exits
- avoid hiding overlay when moving from card to overlay
- fix PyQt stubs for tests
- fix race condition when deleting hover overlay

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fd3816f70832eabefcb8738485fb6