### PR TITLE
Fix filtering to preserve task card list

### DIFF
--- a/ui/dashboard_child_view/grid_layout.py
+++ b/ui/dashboard_child_view/grid_layout.py
@@ -325,7 +325,10 @@ class GridLayout(QWidget):
         # Clear the visible cards list
         self.visibleCards = []
         
-        for card in self.taskCards:
+        # Preserve the existing cards so filtering only affects visibility
+        existing_cards = list(self.taskCards)
+
+        for card in existing_cards:
             # Default visibility
             show_card = True
             task = card.task
@@ -366,7 +369,8 @@ class GridLayout(QWidget):
             if show_card:
                 self.visibleCards.append(card)
 
-            self.taskCards = []
+        # Keep the taskCards list intact
+        self.taskCards = existing_cards
 
         # print(f"{self.grid_title} has these card: {self.taskCards}")
                 


### PR DESCRIPTION
## Summary
- keep `taskCards` list unchanged in `onFilterChanged`
- copy current cards for filtering and restore after visibility updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d3d6bdac832e803e6c7edfd141dd