### PR TITLE
Fix wheel event forwarding in TaskCardLite

### DIFF
--- a/ui/task_files/task_card_lite.py
+++ b/ui/task_files/task_card_lite.py
@@ -270,10 +270,11 @@ class TaskCardLite(QWidget):
                 return True
 
             elif event.type() == QEvent.Wheel:
-                widget_under = QApplication.widgetAt(QCursor.pos())
-                if widget_under and widget_under != self.hoverOverlay:
-                    QApplication.sendEvent(widget_under, event)
-                    return True  # stop propagation after sending
+                # Forward wheel events so scrolling continues to work
+                handled = QApplication.sendEvent(self, event)
+                if not handled and self.parentWidget():
+                    QApplication.sendEvent(self.parentWidget(), event)
+                return True
 
         return False
 


### PR DESCRIPTION
## Summary
- forward wheel events from overlay to the underlying card or parent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841e0e881d0832eb2114bcf8d7a24f9